### PR TITLE
Implement Precision Time Protocol and Synchronous Free Run options

### DIFF
--- a/pylon_camera/include/pylon_camera/internal/pylon_camera.h
+++ b/pylon_camera/include/pylon_camera/internal/pylon_camera.h
@@ -55,7 +55,9 @@ public:
 
     virtual ~PylonCameraImpl();
 
-    virtual bool registerCameraConfiguration();
+    virtual bool registerSoftwareTriggerConfiguration();
+
+    virtual bool registerContinuousConfiguration();
 
     virtual bool openCamera();
 
@@ -304,6 +306,9 @@ protected:
 
     virtual bool setupSequencer(const std::vector<float>& exposure_times,
                                 std::vector<float>& exposure_times_set);
+
+    // We want different frame replacement strategies depending on acquisition method
+    Pylon::EGrabStrategy grab_strategy_ = Pylon::GrabStrategy_OneByOne;
 };
 
 }  // namespace pylon_camera

--- a/pylon_camera/include/pylon_camera/pylon_camera.h
+++ b/pylon_camera/include/pylon_camera/pylon_camera.h
@@ -72,7 +72,13 @@ public:
      * Configures the camera according to the software trigger mode.
      * @return true if all the configuration could be set up.
      */
-    virtual bool registerCameraConfiguration() = 0;
+    virtual bool registerSoftwareTriggerConfiguration() = 0;
+
+    /**
+     * Configures the camera according to the continuous acquisition mode.
+     * @return true if all the configuration could be set up.
+     */
+    virtual bool registerContinuousConfiguration() = 0;
 
     /**
      * Opens the desired camera, the communication starts from now on.

--- a/pylon_camera/include/pylon_camera/pylon_camera_parameter.h
+++ b/pylon_camera/include/pylon_camera/pylon_camera_parameter.h
@@ -119,6 +119,18 @@ public:
     void setCameraInfoURL(const ros::NodeHandle& nh,
                           const std::string& camera_info_url);
 
+
+    /**
+     * Getters for ptp and sync free run parameter server values
+     */
+    bool ptpEnabled() const { return ptp_enable_; };
+    bool ptpMasterAllowed() const { return ptp_allow_master_; }
+    int ptpMaxOffsetNs() const { return ptp_max_offset_ns_; }
+    int ptpOffsetWindowSecs() const { return ptp_offset_window_s_; }
+    bool syncFreeRunEnabled() const { return sync_free_run_; }
+    int syncFreeRunStartLow() const { return sync_free_run_start_low_; }
+    int syncFreeRunStartHigh() const { return sync_free_run_start_high_; }
+
 public:
     /** Binning factor to get downsampled images. It refers here to any camera
      * setting which combines rectangular neighborhoods of pixels into larger
@@ -348,6 +360,44 @@ protected:
      * 'bayer_gbrg8', 'bayer_rggb8' and 'yuv422'
      */
     std::string image_encoding_;
+
+      /**
+     * Enable PTP on the camera. Will block before capturing until PTP is
+     * connected and clock offset is below ptp_max_offset_ns_
+     */
+    bool ptp_enable_;
+
+    /**
+     * If true, camera can be a master clock. Otherwise will not proceed
+     * until camera becomes a slave clock.
+     */
+    bool ptp_allow_master_;
+
+    /**
+     * If ptp is enabled, capture will be blocked until master clock offset
+     * is below this threshold over ptp_offset_window_s_
+     */
+    int ptp_max_offset_ns_;
+
+    /**
+     * Master clock offset must be below ptp_max_offset_ns_ for this duration
+     */
+    int ptp_offset_window_s_;
+
+    /**
+     * Enable synchronous free run. PTP must be enabled as well
+     */
+    bool sync_free_run_;
+
+    /**
+     * Low bits for synchronous free run start offset
+     */
+    int sync_free_run_start_low_;
+
+    /**
+     * High bits for synchronous free run start offset
+     */
+    int sync_free_run_start_high_;
 };
 
 }  // namespace pylon_camera

--- a/pylon_camera/src/pylon_camera/pylon_camera.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera.cpp
@@ -192,8 +192,10 @@ PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
                             << device_user_id_to_open << ": "
                             << it->GetModelName());
                 PYLON_CAM_TYPE cam_type = detectPylonCamType(*it);
-                return createFromDevice(cam_type,
-                                        tl_factory.CreateDevice(*it));
+                PylonCamera* new_cam_ptr = createFromDevice(cam_type,
+                                                            tl_factory.CreateDevice(*it));
+                new_cam_ptr->device_user_id_ = device_user_id_to_open;
+                return new_cam_ptr;
             }
             else
             {

--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -328,7 +328,7 @@ bool PylonCameraNode::initAndRegister()
         return false;
     }
 
-    if ( !pylon_camera_->registerCameraConfiguration() )
+    if ( !pylon_camera_->registerSoftwareTriggerConfiguration() )
     {
         ROS_ERROR_STREAM("Error while registering the camera configuration to "
             << "software-trigger mode!");

--- a/pylon_camera/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_parameter.cpp
@@ -69,7 +69,14 @@ PylonCameraParameter::PylonCameraParameter() :
         inter_pkg_delay_(1000),
         startup_user_set_(""),
         shutter_mode_(SM_DEFAULT),
-        auto_flash_(false)
+        auto_flash_(false),
+        ptp_enable_(false),
+        ptp_allow_master_(false),
+        ptp_max_offset_ns_(1000),
+        ptp_offset_window_s_(2),
+        sync_free_run_(false),
+        sync_free_run_start_low_(0),
+        sync_free_run_start_high_(0)
 {}
 
 PylonCameraParameter::~PylonCameraParameter()
@@ -262,7 +269,16 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     nh.param<bool>("auto_flash_line_2", auto_flash_line_2_, true);
     nh.param<bool>("auto_flash_line_3", auto_flash_line_3_, true);
 
-    ROS_WARN("Autoflash: %i, line2: %i , line3: %i ", auto_flash_, auto_flash_line_2_, auto_flash_line_3_);
+    ROS_INFO("Autoflash: %i, line2: %i , line3: %i ", auto_flash_, auto_flash_line_2_, auto_flash_line_3_);
+
+    nh.param<bool>("ptp_enable", ptp_enable_, ptp_enable_);
+    nh.param<bool>("ptp_allow_master", ptp_allow_master_, ptp_allow_master_);
+    nh.param<int>("ptp_max_offset_ns", ptp_max_offset_ns_, ptp_max_offset_ns_);
+    nh.param<int>("ptp_offset_window_s", ptp_offset_window_s_, ptp_offset_window_s_);
+    nh.param<bool>("sync_free_run", sync_free_run_, sync_free_run_);
+    nh.param<int>("sync_free_run_start_low", sync_free_run_start_low_, sync_free_run_start_low_);
+    nh.param<int>("sync_free_run_start_high", sync_free_run_start_high_, sync_free_run_start_high_);
+
     validateParameterSet(nh);
     return;
 }


### PR DESCRIPTION
- PTP and sync free run can be enabled at startup via ros
  parameters. They are set up within the gige camera's
  applyCamSpecificStartupSettings. Controls are not exposed for
  for further usage like many of the other camera controls though.

- PTP startup will block until sufficient clock synchronization is
  reached, though the detection is not perfect.

- Sync free run requires continuous acquisition mode, which does not
  play nicely with the rest of the code that uses software triggering.
  To accommodate the 2 acquisition modes, we also switch between 2
  grab strategies.

- Also some general bugfixes, e.g. always setting bandwidth parameters
  and device_user_id_